### PR TITLE
re-use the transmissibilities calculated in the context of load balancing for output

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -87,6 +87,11 @@ SET_BOOL_PROP(EclFlowProblem, EnableDebuggingChecks, false);
 // SWATINIT is done by the flow part of flow_ebos. this can be removed once the legacy
 // code for fluid and satfunc handling gets fully retired.
 SET_BOOL_PROP(EclFlowProblem, EnableSwatinit, false);
+
+// For output, we need to access the transmissibilities of the sequential grid after the
+// grid has been load balanced. Tell ebos to not delete it at its initialization
+// proceedure.
+SET_BOOL_PROP(EclFlowProblem, ExportGlobalTransmissibility, true);
 }}
 
 namespace Opm {


### PR DESCRIPTION
this will eventually allow to shove off a few seconds at initialization because the transmissibilities do not need to be calculated one time less and some memory can be potentially freed because the DerivedGeology does not need to be allocated anymore (after some less invasive additional patches). More importantly, this change causes the transmissibilities which are written to disk to be identical to the ones used for linearization automatically.

I checked that this works with Norne in parallel. Uppon visual inspection the output files look the same as for the sequential run, but I have not done any more rigorous comparison.

this depends on https://github.com/OPM/ewoms/pull/147 . (this should be merged the eWoms master soon, though.)